### PR TITLE
feat: add OpenAI embedding support and release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,14 @@ Supported environment variables:
 
 - `LANCEDB_OPENCODE_PRO_CONFIG_PATH`
 - `LANCEDB_OPENCODE_PRO_PROVIDER`
+- `LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER` (`ollama` or `openai`, default `ollama`)
 - `LANCEDB_OPENCODE_PRO_DB_PATH`
 - `LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL`
 - `LANCEDB_OPENCODE_PRO_OLLAMA_BASE_URL`
+- `LANCEDB_OPENCODE_PRO_OPENAI_API_KEY`
+- `LANCEDB_OPENCODE_PRO_OPENAI_MODEL`
+- `LANCEDB_OPENCODE_PRO_OPENAI_BASE_URL`
+- `LANCEDB_OPENCODE_PRO_OPENAI_TIMEOUT_MS`
 - `LANCEDB_OPENCODE_PRO_EMBEDDING_TIMEOUT_MS`
 - `LANCEDB_OPENCODE_PRO_RETRIEVAL_MODE`
 - `LANCEDB_OPENCODE_PRO_VECTOR_WEIGHT`
@@ -226,6 +231,51 @@ Supported environment variables:
   - `memory_clear`
   - `memory_stats`
   - `memory_port_plan`
+
+## OpenAI Embedding Configuration
+
+Default behavior stays on Ollama. To use OpenAI embeddings, set `embedding.provider` to `openai` and provide API key + model.
+
+Example sidecar:
+
+```json
+{
+  "provider": "lancedb-opencode-pro",
+  "dbPath": "~/.opencode/memory/lancedb",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "baseUrl": "https://api.openai.com/v1",
+    "apiKey": "sk-your-openai-key"
+  },
+  "retrieval": {
+    "mode": "hybrid",
+    "vectorWeight": 0.7,
+    "bm25Weight": 0.3,
+    "minScore": 0.2
+  },
+  "includeGlobalScope": true,
+  "minCaptureChars": 80,
+  "maxEntriesPerScope": 3000
+}
+```
+
+Recommended env overrides for OpenAI:
+
+```bash
+export LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER="openai"
+export LANCEDB_OPENCODE_PRO_OPENAI_API_KEY="$OPENAI_API_KEY"
+export LANCEDB_OPENCODE_PRO_OPENAI_MODEL="text-embedding-3-small"
+export LANCEDB_OPENCODE_PRO_OPENAI_BASE_URL="https://api.openai.com/v1"
+```
+
+`lancedb-opencode-pro.json` is parsed as plain JSON, so `${...}` interpolation is not performed. Prefer environment variables for secrets.
+
+Validation behavior:
+
+- If `embedding.provider=openai` and API key is missing, initialization fails with an explicit configuration error.
+- If `embedding.provider=openai` and model is missing, initialization fails with an explicit configuration error.
+- Ollama remains the default provider when `embedding.provider` is omitted.
 
 ## Compose Port Planning (Cross-Project)
 
@@ -511,5 +561,5 @@ Treat the feature as verified only when all of these are true:
 ## Notes
 
 - Default storage path: `~/.opencode/memory/lancedb`
-- Embedding backend in v1: `ollama`
+- Embedding provider defaults to `ollama`; `openai` is supported via `embedding.provider=openai`
 - The provider keeps schema metadata (`schemaVersion`, `embeddingModel`, `vectorDim`) to guard against unsafe vector mixing.

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/design.md
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/design.md
@@ -1,0 +1,66 @@
+## Context
+
+目前 `lancedb-opencode-pro` 的嵌入流程由 `src/config.ts` 與 `src/embedder.ts` 組成，設定與實作都預設 `ollama`，且 `EmbeddingProvider` 型別僅允許 `"ollama"`。這讓插件在本機模型可用時運作良好，但在需要雲端 API、共用企業模型治理或無法部署 Ollama 的環境下無法使用。
+
+此變更需要同時維持既有安裝路徑與預設值（避免破壞現有使用者），並新增 OpenAI 設定能力（API key、base URL、model）與 provider 切換機制。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在不破壞既有 `ollama` 預設行為下，新增 `openai` 嵌入 provider 支援。
+- 定義一致的設定契約與環境變數覆寫規則，讓 sidecar 與 env 可預測地共存。
+- 讓 OpenAI 設定缺漏時快速失敗，錯誤訊息可直接指向修正方式。
+- 維持既有記憶儲存/檢索流程（capture/search/delete/clear）不需要改變業務語意。
+
+**Non-Goals:**
+- 不在本次引入多雲 provider 管理框架（例如 Azure/OpenRouter 一次到位）。
+- 不改動記憶資料表結構與 LanceDB 儲存格式。
+- 不在本次加入成本控制、配額治理或模型自動降級策略。
+
+## Decisions
+
+### 1) Provider 型別擴充為聯集
+- Decision: 將 `EmbeddingProvider` 由單一 `ollama` 擴充為 `ollama | openai`，並保留預設 provider 為 `ollama`。
+- Rationale: 以最小破壞方式擴充能力，維持舊設定檔與舊環境變數在未變更時完全可用。
+- Alternative considered: 直接改為通用字串 provider；拒絕，因為會失去型別保護與設定驗證品質。
+
+### 2) 以 provider-aware factory 建立 embedder
+- Decision: 在 `src/embedder.ts` 引入工廠函式，依 `embedding.provider` 回傳 `OllamaEmbedder` 或 `OpenAIEmbedder`。
+- Rationale: 將 provider 分派集中在單一入口，避免在 `src/index.ts` 分散條件判斷。
+- Alternative considered: 在 `index.ts` 直接 `if/else` 建構；拒絕，因為擴充第三個 provider 時會惡化可維護性。
+
+### 3) OpenAI 設定採最小必要欄位
+- Decision: `openai` 路徑至少要求 API key 與 model，`baseUrl` 為可選（預設官方 endpoint）。
+- Rationale: 與官方 SDK 使用習慣一致，也能覆蓋代理或 OpenAI-compatible endpoint 場景。
+- Alternative considered: 僅允許 API key 不允許 baseUrl；拒絕，因為會限制企業代理與相容端點。
+
+### 4) 設定優先序延續既有規則
+- Decision: 保持既有 precedence（env > config path > project sidecar > global sidecar > legacy > default），只新增 OpenAI 對應環境變數。
+- Rationale: 使用者已熟悉此規則，避免在新增 provider 時引入不可預期覆寫行為。
+- Alternative considered: 為 OpenAI 建立獨立 precedence；拒絕，因為會提高心智負擔。
+
+### 5) 啟動時驗證 OpenAI 關鍵欄位
+- Decision: 當 `provider=openai` 時，若缺 API key 或 model，初始化直接失敗並提供可行修正提示。
+- Rationale: 及早暴露設定錯誤比延後到查詢時失敗更易排障。
+- Alternative considered: 缺漏時靜默回退到 ollama；拒絕，因為會造成行為不透明與錯誤定位困難。
+
+## Risks / Trade-offs
+
+- [OpenAI 模型向量維度與既有資料不一致] -> Mitigation: 延續既有 `embeddingModel`/`vectorDim` 相容檢查，偵測不相容時阻擋混用並提示重建。
+- [API key 管理不當造成洩漏風險] -> Mitigation: 文件與錯誤訊息強制導向環境變數，避免在範例中硬編碼金鑰。
+- [網路型 provider 增加 timeout/重試複雜度] -> Mitigation: 保留可設定 timeout，並在錯誤路徑輸出 provider 與 endpoint 便於診斷。
+- [雙 provider 文件變長、入門成本提升] -> Mitigation: README 保留「預設 Ollama 最短路徑」與「OpenAI 進階路徑」分段。
+
+## Migration Plan
+
+1. 擴充型別與設定解析，先讓 `openai` 設定可被讀取與驗證。
+2. 實作 `OpenAIEmbedder` 並加入 embedder factory，替換目前硬編碼 `new OllamaEmbedder(...)`。
+3. 補齊 provider 切換、設定錯誤與相容性相關測試。
+4. 更新 README 設定範例與環境變數清單，明確標示預設仍為 Ollama。
+5. 以 Docker 測試流程執行 typecheck/build/test，確認舊設定不回歸。
+6. Rollback: 若發現相容性問題，可將 `embedding.provider` 設回 `ollama` 並移除 OpenAI 相關 env vars。
+
+## Open Questions
+
+- OpenAI 路徑是否採 SDK 依賴或維持 `fetch` 直接呼叫，以平衡依賴體積與實作一致性？
+- 是否在 v1 同步支援 OpenAI-compatible embedding 路徑（例如 `/v1/embeddings` 但不同供應商）的額外 header 設定？

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/proposal.md
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+目前記憶向量嵌入設定僅支援 `ollama`，對需要雲端託管模型或無法維運本機 Ollama 的使用者不夠彈性。為了讓相同記憶流程可在本機與雲端環境一致運作，需要在保留預設 Ollama 的前提下新增 OpenAI API 與模型設定能力。
+
+## What Changes
+
+- Extend embedding provider configuration to support both `ollama` and `openai` without breaking existing defaults.
+- Add OpenAI-specific configuration fields and environment variable overrides for API key, base URL, and embedding model selection.
+- Add provider selection and validation behavior so invalid or incomplete OpenAI settings fail fast with actionable errors.
+- Update documentation and examples to show sidecar config and env-var precedence for dual-provider usage.
+
+## Capabilities
+
+### New Capabilities
+- `openai-embedding-provider`: 提供 OpenAI 向量嵌入請求路徑，支援 API key、模型與 endpoint 設定，並與既有記憶寫入/搜尋流程整合。
+
+### Modified Capabilities
+- `memory-provider-config`: 將既有僅 Ollama 的嵌入設定契約擴充為多 provider，明確定義預設值、覆寫優先序與錯誤處理。
+
+## Impact
+
+- Affected code: `src/types.ts`, `src/config.ts`, `src/embedder.ts`, `src/index.ts`, and related tests/documentation.
+- External dependencies: 可能新增 OpenAI SDK（或以標準 fetch 直接呼叫 OpenAI-compatible endpoint）。
+- Operational concerns: API 金鑰管理、模型維度差異相容性、網路/限流失敗重試策略。
+- Backward compatibility: 維持預設 `ollama` 行為，未提供 OpenAI 設定時不改變現有安裝與執行路徑。

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/specs/memory-provider-config/spec.md
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/specs/memory-provider-config/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Memory provider configuration contract
+The system MUST support a memory configuration contract in sidecar config and environment variables with provider id, storage path, embedding settings, and retrieval settings, including both `ollama` and `openai` embedding providers.
+
+#### Scenario: Valid provider configuration is loaded
+- **WHEN** memory config contains `provider = "lancedb-opencode-pro"` with valid `dbPath`, `embedding`, and `retrieval` fields
+- **THEN** the provider configuration is accepted and initialized without fallback
+
+#### Scenario: Missing optional retrieval values uses defaults
+- **WHEN** `memory.retrieval` omits weights or mode fields
+- **THEN** the system applies documented defaults including `mode = hybrid`, `vectorWeight = 0.7`, and `bm25Weight = 0.3`
+
+#### Scenario: Embedding provider defaults to ollama
+- **WHEN** `memory.embedding.provider` is omitted
+- **THEN** the system defaults embedding provider to `ollama` to preserve backward compatibility
+
+#### Scenario: Environment variable overrides embedding provider settings
+- **WHEN** OpenAI or Ollama embedding settings are provided in supported environment variables
+- **THEN** environment variable values override sidecar configuration according to documented precedence

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/specs/openai-embedding-provider/spec.md
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/specs/openai-embedding-provider/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: OpenAI embedding provider execution
+The system MUST support an `openai` embedding provider that requests embeddings from an OpenAI-compatible API endpoint and returns vectors consumable by the existing memory write and search pipeline.
+
+#### Scenario: OpenAI embedding request succeeds
+- **WHEN** `embedding.provider` is `openai` and valid `apiKey` and `model` are configured
+- **THEN** the system sends an embedding request to the configured OpenAI endpoint and uses the returned vector for memory indexing or retrieval
+
+#### Scenario: OpenAI endpoint override is configured
+- **WHEN** `embedding.provider` is `openai` and `embedding.baseUrl` is configured
+- **THEN** the system uses the configured base URL instead of the default OpenAI endpoint
+
+### Requirement: OpenAI provider configuration validation
+The system MUST fail fast with actionable validation errors when `openai` provider settings are incomplete or invalid.
+
+#### Scenario: Missing API key for openai provider
+- **WHEN** `embedding.provider` is `openai` and no OpenAI API key is resolved from configuration or environment
+- **THEN** initialization fails with an explicit error that indicates which key is missing and how to provide it
+
+#### Scenario: Missing model for openai provider
+- **WHEN** `embedding.provider` is `openai` and no model is configured
+- **THEN** initialization fails with an explicit error that requests a valid OpenAI embedding model name

--- a/openspec/changes/archive/2026-03-17-support-openai-api-model-config/tasks.md
+++ b/openspec/changes/archive/2026-03-17-support-openai-api-model-config/tasks.md
@@ -1,0 +1,29 @@
+## 1. Type and Config Contract
+
+- [x] 1.1 Extend embedding provider types to include `openai` while preserving `ollama` default behavior.
+- [x] 1.2 Add OpenAI-related runtime config fields and environment variable resolution in config parsing.
+- [x] 1.3 Add startup validation rules for `provider=openai` required fields (API key, model).
+
+## 2. Embedder Implementation
+
+- [x] 2.1 Implement `OpenAIEmbedder` that conforms to the existing `Embedder` interface.
+- [x] 2.2 Add provider-aware embedder factory and route provider initialization through the factory.
+- [x] 2.3 Keep Ollama embedder behavior unchanged for existing configurations.
+
+## 3. Integration and Compatibility
+
+- [x] 3.1 Wire provider selection through plugin initialization (`src/index.ts`) without changing memory workflow semantics.
+- [x] 3.2 Ensure embedding metadata compatibility checks continue to prevent mixed-dimension unsafe retrieval.
+- [x] 3.3 Add clear error messages for provider misconfiguration and upstream API failures.
+
+## 4. Tests and Documentation
+
+- [x] 4.1 Add or update tests for config precedence and provider switching (ollama/openai).
+- [x] 4.2 Add tests for openai validation failures (missing apiKey/model) and successful embedding path.
+- [x] 4.3 Update README sidecar examples and environment variable list to document OpenAI + Ollama support.
+
+## 5. Verification
+
+- [x] 5.1 Run Docker validation flow: `docker compose build --no-cache && docker compose up -d`.
+- [x] 5.2 Run typecheck/build/tests in container with `docker compose exec` and confirm no regressions.
+- [x] 5.3 Capture verification evidence and note rollback path (`provider` revert to `ollama`).

--- a/openspec/specs/memory-provider-config/spec.md
+++ b/openspec/specs/memory-provider-config/spec.md
@@ -4,15 +4,23 @@
 TBD - created by archiving change add-lancedb-memory-provider. Update Purpose after archive.
 ## Requirements
 ### Requirement: Memory provider configuration contract
-The system MUST support a memory configuration contract in `opencode.json` with provider id, storage path, embedding settings, and retrieval settings.
+The system MUST support a memory configuration contract in sidecar config and environment variables with provider id, storage path, embedding settings, and retrieval settings, including both `ollama` and `openai` embedding providers.
 
 #### Scenario: Valid provider configuration is loaded
-- **WHEN** `opencode.json` contains `memory.provider = "lancedb-opencode-pro"` with valid `dbPath`, `embedding`, and `retrieval` fields
+- **WHEN** memory config contains `provider = "lancedb-opencode-pro"` with valid `dbPath`, `embedding`, and `retrieval` fields
 - **THEN** the provider configuration is accepted and initialized without fallback
 
 #### Scenario: Missing optional retrieval values uses defaults
 - **WHEN** `memory.retrieval` omits weights or mode fields
 - **THEN** the system applies documented defaults including `mode = hybrid`, `vectorWeight = 0.7`, and `bm25Weight = 0.3`
+
+#### Scenario: Embedding provider defaults to ollama
+- **WHEN** `memory.embedding.provider` is omitted
+- **THEN** the system defaults embedding provider to `ollama` to preserve backward compatibility
+
+#### Scenario: Environment variable overrides embedding provider settings
+- **WHEN** OpenAI or Ollama embedding settings are provided in supported environment variables
+- **THEN** environment variable values override sidecar configuration according to documented precedence
 
 ### Requirement: Default storage path behavior
 The system MUST default memory storage path to `~/.opencode/memory/lancedb` when `memory.dbPath` is not explicitly configured, and the project MUST provide a supported verification path for operators to inspect the active storage location.

--- a/openspec/specs/openai-embedding-provider/spec.md
+++ b/openspec/specs/openai-embedding-provider/spec.md
@@ -1,0 +1,27 @@
+# openai-embedding-provider Specification
+
+## Purpose
+TBD - created by archiving change support-openai-api-model-config. Update Purpose after archive.
+## Requirements
+### Requirement: OpenAI embedding provider execution
+The system MUST support an `openai` embedding provider that requests embeddings from an OpenAI-compatible API endpoint and returns vectors consumable by the existing memory write and search pipeline.
+
+#### Scenario: OpenAI embedding request succeeds
+- **WHEN** `embedding.provider` is `openai` and valid `apiKey` and `model` are configured
+- **THEN** the system sends an embedding request to the configured OpenAI endpoint and uses the returned vector for memory indexing or retrieval
+
+#### Scenario: OpenAI endpoint override is configured
+- **WHEN** `embedding.provider` is `openai` and `embedding.baseUrl` is configured
+- **THEN** the system uses the configured base URL instead of the default OpenAI endpoint
+
+### Requirement: OpenAI provider configuration validation
+The system MUST fail fast with actionable validation errors when `openai` provider settings are incomplete or invalid.
+
+#### Scenario: Missing API key for openai provider
+- **WHEN** `embedding.provider` is `openai` and no OpenAI API key is resolved from configuration or environment
+- **THEN** initialization fails with an explicit error that indicates which key is missing and how to provide it
+
+#### Scenario: Missing model for openai provider
+- **WHEN** `embedding.provider` is `openai` and no model is configured
+- **THEN** initialization fails with an explicit error that requests a valid OpenAI embedding model name
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lancedb-opencode-pro",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.26.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Config } from "@opencode-ai/sdk";
-import type { MemoryRuntimeConfig, RetrievalMode } from "./types.js";
+import type { EmbeddingProvider, MemoryRuntimeConfig, RetrievalMode } from "./types.js";
 import { clamp, expandHomePath, parseJsonObject, toBoolean, toNumber } from "./utils.js";
 
 const DEFAULT_DB_PATH = "~/.opencode/memory/lancedb";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const SIDECAR_FILE = "lancedb-opencode-pro.json";
 
 export function resolveMemoryConfig(config: Config | undefined, worktree?: string): MemoryRuntimeConfig {
@@ -28,16 +29,42 @@ export function resolveMemoryConfig(config: Config | undefined, worktree?: strin
   const normalizedVectorWeight = weightSum > 0 ? vectorWeight / weightSum : 0.7;
   const normalizedBm25Weight = weightSum > 0 ? bm25Weight / weightSum : 0.3;
 
-  return {
+  const embeddingProvider = resolveEmbeddingProvider(
+    firstString(process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER, embeddingRaw.provider),
+  );
+  const embeddingModel =
+    embeddingProvider === "openai"
+      ? firstString(
+          process.env.LANCEDB_OPENCODE_PRO_OPENAI_MODEL,
+          process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL,
+          embeddingRaw.model,
+        )
+      : firstString(process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL, embeddingRaw.model) ?? "nomic-embed-text";
+  const embeddingBaseUrl =
+    embeddingProvider === "openai"
+      ? firstString(process.env.LANCEDB_OPENCODE_PRO_OPENAI_BASE_URL, embeddingRaw.baseUrl) ?? DEFAULT_OPENAI_BASE_URL
+      : firstString(process.env.LANCEDB_OPENCODE_PRO_OLLAMA_BASE_URL, embeddingRaw.baseUrl) ?? DEFAULT_OLLAMA_BASE_URL;
+  const embeddingApiKey =
+    embeddingProvider === "openai"
+      ? firstString(process.env.LANCEDB_OPENCODE_PRO_OPENAI_API_KEY, embeddingRaw.apiKey)
+      : undefined;
+  const timeoutEnv =
+    embeddingProvider === "openai"
+      ? process.env.LANCEDB_OPENCODE_PRO_OPENAI_TIMEOUT_MS ?? process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_TIMEOUT_MS
+      : process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_TIMEOUT_MS;
+  const timeoutRaw = timeoutEnv ?? embeddingRaw.timeoutMs;
+
+  const resolvedConfig: MemoryRuntimeConfig = {
     provider,
     dbPath,
     embedding: {
-      provider: "ollama",
-      model: firstString(process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL, embeddingRaw.model) ?? "nomic-embed-text",
-      baseUrl: firstString(process.env.LANCEDB_OPENCODE_PRO_OLLAMA_BASE_URL, embeddingRaw.baseUrl) ?? DEFAULT_OLLAMA_BASE_URL,
+      provider: embeddingProvider,
+      model: embeddingModel ?? "",
+      baseUrl: embeddingBaseUrl,
+      apiKey: embeddingApiKey,
       timeoutMs: Math.max(
         500,
-        Math.floor(toNumber(process.env.LANCEDB_OPENCODE_PRO_EMBEDDING_TIMEOUT_MS ?? embeddingRaw.timeoutMs, 6000)),
+        Math.floor(toNumber(timeoutRaw, 6000)),
       ),
     },
     retrieval: {
@@ -56,6 +83,31 @@ export function resolveMemoryConfig(config: Config | undefined, worktree?: strin
       Math.floor(toNumber(process.env.LANCEDB_OPENCODE_PRO_MAX_ENTRIES_PER_SCOPE ?? raw.maxEntriesPerScope, 3000)),
     ),
   };
+
+  validateEmbeddingConfig(resolvedConfig.embedding);
+  return resolvedConfig;
+}
+
+function resolveEmbeddingProvider(raw: string | undefined): EmbeddingProvider {
+  if (!raw || raw === "ollama") return "ollama";
+  if (raw === "openai") return "openai";
+  throw new Error(
+    `[lancedb-opencode-pro] Invalid embedding provider "${raw}". Expected "ollama" or "openai".`,
+  );
+}
+
+function validateEmbeddingConfig(embedding: MemoryRuntimeConfig["embedding"]): void {
+  if (embedding.provider !== "openai") return;
+  if (!embedding.apiKey) {
+    throw new Error(
+      "[lancedb-opencode-pro] OpenAI embedding provider requires apiKey. Set embedding.apiKey or LANCEDB_OPENCODE_PRO_OPENAI_API_KEY.",
+    );
+  }
+  if (!embedding.model) {
+    throw new Error(
+      "[lancedb-opencode-pro] OpenAI embedding provider requires model. Set embedding.model or LANCEDB_OPENCODE_PRO_OPENAI_MODEL.",
+    );
+  }
 }
 
 function loadSidecarConfig(worktree?: string): Record<string, unknown> {

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -10,11 +10,20 @@ interface OllamaEmbeddingResponse {
   embedding?: number[];
 }
 
+interface OpenAIEmbeddingResponse {
+  data?: Array<{
+    embedding?: number[];
+  }>;
+}
+
 const KNOWN_MODEL_DIMS: Record<string, number> = {
   "nomic-embed-text": 768,
   "mxbai-embed-large": 1024,
   "all-minilm": 384,
   "snowflake-arctic-embed": 1024,
+  "text-embedding-3-small": 1536,
+  "text-embedding-3-large": 3072,
+  "text-embedding-ada-002": 1536,
 };
 
 function fallbackDim(model: string): number | null {
@@ -89,4 +98,89 @@ export class OllamaEmbedder implements Embedder {
       );
     }
   }
+}
+
+export class OpenAIEmbedder implements Embedder {
+  readonly model: string;
+  private cachedDim: number | null = null;
+
+  constructor(private readonly config: EmbeddingConfig) {
+    this.model = config.model;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    if (!this.config.apiKey) {
+      throw new Error(
+        "OpenAI embedding request failed: missing apiKey. Set embedding.apiKey or LANCEDB_OPENCODE_PRO_OPENAI_API_KEY.",
+      );
+    }
+
+    const baseUrl = (this.config.baseUrl ?? "https://api.openai.com/v1").replace(/\/+$/, "");
+    const endpoint = `${baseUrl}/embeddings`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs ?? 6000);
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.config.model,
+          input: text,
+          encoding_format: "float",
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const details = await response.text().catch(() => "");
+        const suffix = details ? ` - ${details.slice(0, 240)}` : "";
+        throw new Error(`OpenAI embedding request failed: HTTP ${response.status}${suffix}`);
+      }
+
+      const data = (await response.json()) as OpenAIEmbeddingResponse;
+      const vector = data.data?.[0]?.embedding;
+      if (!Array.isArray(vector) || vector.length === 0) {
+        throw new Error("OpenAI embedding response missing embedding vector");
+      }
+
+      if (this.cachedDim === null) {
+        this.cachedDim = vector.length;
+      }
+
+      return vector;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async dim(): Promise<number> {
+    if (this.cachedDim !== null) return this.cachedDim;
+    try {
+      const probe = await this.embed("dimension probe");
+      this.cachedDim = probe.length;
+      return this.cachedDim;
+    } catch {
+      const fb = fallbackDim(this.model);
+      if (fb !== null) {
+        console.warn(
+          `[lancedb-opencode-pro] OpenAI embedding probe failed, using fallback dim ${fb} for model "${this.model}"`,
+        );
+        return fb;
+      }
+      throw new Error(
+        `OpenAI embedding probe failed and no known fallback dimension for model "${this.model}"`,
+      );
+    }
+  }
+}
+
+export function createEmbedder(config: EmbeddingConfig): Embedder {
+  if (config.provider === "openai") {
+    return new OpenAIEmbedder(config);
+  }
+  return new OllamaEmbedder(config);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import type { Hooks, Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import type { Part, TextPart } from "@opencode-ai/sdk";
 import { resolveMemoryConfig } from "./config.js";
-import { OllamaEmbedder } from "./embedder.js";
+import { createEmbedder } from "./embedder.js";
+import type { Embedder } from "./embedder.js";
 import { extractCaptureCandidate } from "./extract.js";
 import { isTcpPortAvailable, parsePortReservations, planPorts, reservationKey } from "./ports.js";
 import { buildScopeFilter, deriveProjectScope } from "./scope.js";
@@ -17,7 +18,12 @@ const plugin: Plugin = async (input) => {
 
   const hooks: Hooks = {
     config: async (config) => {
-      state.config = resolveMemoryConfig(config, input.worktree);
+      const nextConfig = resolveMemoryConfig(config, input.worktree);
+      if (hasEmbeddingConfigChanged(state.config.embedding, nextConfig.embedding)) {
+        state.embedder = createEmbedder(nextConfig.embedding);
+        state.initialized = false;
+      }
+      state.config = nextConfig;
     },
     event: async ({ event }) => {
       if (event.type === "session.idle" || event.type === "session.compacted") {
@@ -79,7 +85,7 @@ const plugin: Plugin = async (input) => {
         },
         execute: async (args, context) => {
           await state.ensureInitialized();
-          if (!state.initialized) return "Memory store unavailable (Ollama may be offline). Will retry automatically.";
+          if (!state.initialized) return unavailableMessage(state.config.embedding.provider);
           const activeScope = args.scope ?? deriveProjectScope(context.worktree);
           const scopes = buildScopeFilter(activeScope, state.config.includeGlobalScope);
 
@@ -119,7 +125,7 @@ const plugin: Plugin = async (input) => {
         },
         execute: async (args, context) => {
           await state.ensureInitialized();
-          if (!state.initialized) return "Memory store unavailable (Ollama may be offline). Will retry automatically.";
+          if (!state.initialized) return unavailableMessage(state.config.embedding.provider);
           if (!args.confirm) {
             return "Rejected: memory_delete requires confirm=true.";
           }
@@ -137,7 +143,7 @@ const plugin: Plugin = async (input) => {
         },
         execute: async (args) => {
           await state.ensureInitialized();
-          if (!state.initialized) return "Memory store unavailable (Ollama may be offline). Will retry automatically.";
+          if (!state.initialized) return unavailableMessage(state.config.embedding.provider);
           if (!args.confirm) {
             return "Rejected: destructive clear requires confirm=true.";
           }
@@ -152,7 +158,7 @@ const plugin: Plugin = async (input) => {
         },
         execute: async (args, context) => {
           await state.ensureInitialized();
-          if (!state.initialized) return "Memory store unavailable (Ollama may be offline). Will retry automatically.";
+          if (!state.initialized) return unavailableMessage(state.config.embedding.provider);
           const scope = args.scope ?? deriveProjectScope(context.worktree);
           const entries = await state.store.list(scope, 20);
           const incompatibleVectors = await state.store.countIncompatibleVectors(
@@ -194,7 +200,7 @@ const plugin: Plugin = async (input) => {
         },
         execute: async (args, context) => {
           await state.ensureInitialized();
-          if (!state.initialized) return "Memory store unavailable (Ollama may be offline). Will retry automatically.";
+          if (!state.initialized) return unavailableMessage(state.config.embedding.provider);
           if (args.rangeStart > args.rangeEnd) {
             return "Invalid range: rangeStart must be <= rangeEnd.";
           }
@@ -291,7 +297,7 @@ const plugin: Plugin = async (input) => {
 
 async function createRuntimeState(input: Parameters<Plugin>[0]): Promise<RuntimeState> {
   const resolved = resolveMemoryConfig(undefined, input.worktree);
-  const embedder = new OllamaEmbedder(resolved.embedding);
+  const embedder = createEmbedder(resolved.embedding);
   const store = new MemoryStore(resolved.dbPath);
 
   const state: RuntimeState = {
@@ -419,12 +425,26 @@ function unwrapData(value: unknown): unknown {
 
 interface RuntimeState {
   config: MemoryRuntimeConfig;
-  embedder: OllamaEmbedder;
+  embedder: Embedder;
   store: MemoryStore;
   defaultScope: string;
   initialized: boolean;
   captureBuffer: Map<string, string[]>;
   ensureInitialized: () => Promise<void>;
+}
+
+function unavailableMessage(provider: string): string {
+  return `Memory store unavailable (${provider} embedding may be offline). Will retry automatically.`;
+}
+
+function hasEmbeddingConfigChanged(current: MemoryRuntimeConfig["embedding"], next: MemoryRuntimeConfig["embedding"]): boolean {
+  return (
+    current.provider !== next.provider
+    || current.model !== next.model
+    || (current.baseUrl ?? "") !== (next.baseUrl ?? "")
+    || (current.apiKey ?? "") !== (next.apiKey ?? "")
+    || (current.timeoutMs ?? 0) !== (next.timeoutMs ?? 0)
+  );
 }
 
 export default plugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type EmbeddingProvider = "ollama";
+export type EmbeddingProvider = "ollama" | "openai";
 
 export type RetrievalMode = "hybrid" | "vector";
 
@@ -8,6 +8,7 @@ export interface EmbeddingConfig {
   provider: EmbeddingProvider;
   model: string;
   baseUrl?: string;
+  apiKey?: string;
   timeoutMs?: number;
 }
 

--- a/test/regression/plugin.test.ts
+++ b/test/regression/plugin.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { resolveMemoryConfig } from "../../src/config.js";
 import plugin from "../../src/index.js";
 import { cleanupDbPath, createScopedRecords, createTempDbPath, createTestStore, createVector } from "../setup.js";
 
@@ -17,8 +18,25 @@ function makeEmbedding(prompt: string, dim = 384): number[] {
 
 function createFetchMock() {
   return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-    const body = typeof init?.body === "string" ? JSON.parse(init.body) as { prompt?: string } : {};
-    const prompt = body.prompt ?? String(input);
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) as { prompt?: string; input?: string | string[] } : {};
+    const url = typeof input === "string" ? input : input instanceof URL ? String(input) : input.url;
+    const textInput = Array.isArray(body.input) ? body.input[0] : body.input;
+    const prompt = body.prompt ?? textInput ?? url;
+
+    if (url.includes("/api/embeddings")) {
+      return new Response(JSON.stringify({ embedding: makeEmbedding(prompt) }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.includes("/embeddings")) {
+      return new Response(JSON.stringify({ data: [{ embedding: makeEmbedding(prompt, 1536) }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     return new Response(JSON.stringify({ embedding: makeEmbedding(prompt) }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -61,16 +79,19 @@ async function createPluginHarness(options?: {
   maxEntriesPerScope?: number;
   userMessages?: SessionMessage[];
   sessionDirectory?: string;
+  embeddingProvider?: "ollama" | "openai";
 }) {
+  const embeddingProvider = options?.embeddingProvider ?? "ollama";
   const dbPath = await createTempDbPath("lancedb-opencode-pro-regression-");
   const memoryConfig = {
     memory: {
       provider: "lancedb-opencode-pro",
       dbPath,
       embedding: {
-        provider: "ollama" as const,
-        model: "all-minilm",
-        baseUrl: "http://127.0.0.1:11434",
+        provider: embeddingProvider,
+        model: embeddingProvider === "openai" ? "text-embedding-3-small" : "all-minilm",
+        baseUrl: embeddingProvider === "openai" ? "https://api.openai.com/v1" : "http://127.0.0.1:11434",
+        ...(embeddingProvider === "openai" ? { apiKey: "test-openai-api-key" } : {}),
       },
       retrieval: {
         mode: "hybrid" as const,
@@ -90,15 +111,24 @@ async function createPluginHarness(options?: {
     },
   ];
   const sessionDirectory = options?.sessionDirectory ?? WORKTREE;
+  const envValues: Record<string, string> = {
+    LANCEDB_OPENCODE_PRO_DB_PATH: dbPath,
+    LANCEDB_OPENCODE_PRO_MIN_CAPTURE_CHARS: String(memoryConfig.memory.minCaptureChars),
+    LANCEDB_OPENCODE_PRO_MAX_ENTRIES_PER_SCOPE: String(memoryConfig.memory.maxEntriesPerScope),
+    LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER: memoryConfig.memory.embedding.provider,
+    LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL: memoryConfig.memory.embedding.model,
+  };
+
+  if (embeddingProvider === "openai") {
+    envValues.LANCEDB_OPENCODE_PRO_OPENAI_API_KEY = "test-openai-api-key";
+    envValues.LANCEDB_OPENCODE_PRO_OPENAI_BASE_URL = memoryConfig.memory.embedding.baseUrl;
+    envValues.LANCEDB_OPENCODE_PRO_OPENAI_MODEL = memoryConfig.memory.embedding.model;
+  } else {
+    envValues.LANCEDB_OPENCODE_PRO_OLLAMA_BASE_URL = memoryConfig.memory.embedding.baseUrl;
+  }
 
   const hooks = await withPatchedEnv(
-    {
-      LANCEDB_OPENCODE_PRO_DB_PATH: dbPath,
-      LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL: memoryConfig.memory.embedding.model,
-      LANCEDB_OPENCODE_PRO_OLLAMA_BASE_URL: memoryConfig.memory.embedding.baseUrl,
-      LANCEDB_OPENCODE_PRO_MIN_CAPTURE_CHARS: String(memoryConfig.memory.minCaptureChars),
-      LANCEDB_OPENCODE_PRO_MAX_ENTRIES_PER_SCOPE: String(memoryConfig.memory.maxEntriesPerScope),
-    },
+    envValues,
     () => withPatchedFetch(async () =>
       plugin({
       client: {
@@ -202,7 +232,7 @@ test("auto-capture stores qualifying output with decision category and skips sho
       harness.toolHooks.memory_search.execute({ query: "Postgres migration design", limit: 5 }, harness.context),
     );
 
-    assert.match(searchOutput, /^1\. \[[^\]]+\] \([^\)]+\) /m);
+    assert.match(searchOutput, /^1\. \[[^\]]+\] \([^)]*\) /m);
     assert.match(searchOutput, /Postgres/);
 
     const statsOutput = await withPatchedFetch(() => harness.toolHooks.memory_stats.execute({}, harness.context));
@@ -223,11 +253,110 @@ test("memory_search returns ranked entries with stable identifiers and readable 
 
     const lines = searchOutput.split("\n");
     assert.ok(lines.length >= 1);
-    assert.match(lines[0], /^1\. \[[^\]]+\] \([^\)]+\) .+ \[\d+%\]$/);
+    assert.match(lines[0], /^1\. \[[^\]]+\] \([^)]*\) .+ \[\d+%\]$/);
     assert.match(searchOutput, /proxy_buffer_size|Nginx 502/);
   } finally {
     await harness.cleanup();
   }
+});
+
+test("openai provider path captures and recalls memory with the same tool surface", async () => {
+  const harness = await createPluginHarness({ embeddingProvider: "openai" });
+
+  try {
+    await harness.capture(
+      "OpenAI path resolved successfully: rotate token and flush upstream cache to resolve 401 storms.",
+    );
+    const searchOutput = await withPatchedFetch(() =>
+      harness.toolHooks.memory_search.execute({ query: "rotate token upstream cache 401", limit: 5 }, harness.context),
+    );
+
+    assert.match(searchOutput, /^1\. \[[^\]]+\] \([^)]*\) /m);
+    assert.match(searchOutput, /rotate token|upstream cache|401/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("resolveMemoryConfig fails fast for openai without apiKey", () => {
+  assert.throws(
+    () =>
+      resolveMemoryConfig(
+        {
+          memory: {
+            provider: "lancedb-opencode-pro",
+            embedding: {
+              provider: "openai",
+              model: "text-embedding-3-small",
+            },
+          },
+        } as unknown as Parameters<typeof resolveMemoryConfig>[0],
+        undefined,
+      ),
+    /requires apiKey/i,
+  );
+});
+
+test("resolveMemoryConfig fails fast for openai without model", () => {
+  assert.throws(
+    () =>
+      resolveMemoryConfig(
+        {
+          memory: {
+            provider: "lancedb-opencode-pro",
+            embedding: {
+              provider: "openai",
+              apiKey: "test-openai-api-key",
+            },
+          },
+        } as unknown as Parameters<typeof resolveMemoryConfig>[0],
+        undefined,
+      ),
+    /requires model/i,
+  );
+});
+
+test("environment overrides can switch embedding provider to openai", async () => {
+  await withPatchedEnv(
+    {
+      LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER: "openai",
+      LANCEDB_OPENCODE_PRO_OPENAI_API_KEY: "env-openai-key",
+      LANCEDB_OPENCODE_PRO_OPENAI_MODEL: "text-embedding-3-small",
+    },
+    async () => {
+      const resolved = resolveMemoryConfig(
+        {
+          memory: {
+            provider: "lancedb-opencode-pro",
+            embedding: {
+              provider: "ollama",
+              model: "all-minilm",
+              baseUrl: "http://127.0.0.1:11434",
+            },
+          },
+        } as unknown as Parameters<typeof resolveMemoryConfig>[0],
+        undefined,
+      );
+
+      assert.equal(resolved.embedding.provider, "openai");
+      assert.equal(resolved.embedding.model, "text-embedding-3-small");
+      assert.equal(resolved.embedding.apiKey, "env-openai-key");
+    },
+  );
+});
+
+test("resolveMemoryConfig rejects invalid embedding provider values", async () => {
+  await withPatchedEnv(
+    {
+      LANCEDB_OPENCODE_PRO_EMBEDDING_PROVIDER: "azure",
+    },
+    async () => {
+      assert.throws(
+        () => resolveMemoryConfig(undefined, undefined),
+        /Invalid embedding provider/i,
+      );
+    },
+  );
 });
 
 test("memory_delete and memory_clear reject destructive operations without confirmation", async () => {
@@ -240,9 +369,10 @@ test("memory_delete and memory_clear reject destructive operations without confi
     );
     const recordId = searchOutput.match(/\[([^\]]+)\]/)?.[1];
     assert.ok(recordId);
+    const ensuredRecordId = recordId ?? "";
 
     const deleteRejected = await withPatchedFetch(() =>
-      harness.toolHooks.memory_delete.execute({ id: recordId!, confirm: false }, harness.context),
+      harness.toolHooks.memory_delete.execute({ id: ensuredRecordId, confirm: false }, harness.context),
     );
     assert.match(deleteRejected, /confirm=true/);
 
@@ -258,7 +388,7 @@ test("memory_delete and memory_clear reject destructive operations without confi
     const searchAfterRejections = await withPatchedFetch(() =>
       harness.toolHooks.memory_search.execute({ query: "stale token API gateway", limit: 5 }, harness.context),
     );
-    assert.match(searchAfterRejections, new RegExp(recordId!));
+    assert.match(searchAfterRejections, new RegExp(ensuredRecordId));
   } finally {
     await harness.cleanup();
   }


### PR DESCRIPTION
## Summary
- add OpenAI embedding provider support alongside the existing Ollama default, including provider-aware config parsing, validation, and runtime embedder selection
- add regression coverage for OpenAI success path, missing api key/model validation, invalid provider handling, and environment-variable override behavior
- archive the completed OpenSpec change, sync specs, and bump package version to 0.1.2 for release