### PR TITLE
chore: release 0.1.6 schema-upgrade patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.1.6] - 2026-03-20
+
+### Fixed
+- Patch pre-`0.1.5` `effectiveness_events` tables during store initialization so upgraded installs automatically add the missing `source` column before new recall events are written.
+- Preserve backward-compatible recall summaries for upgraded databases by treating legacy rows without `source` as `"system-transform"` while allowing new `"manual-search"` events to persist normally.
+- Add foundation and regression coverage for the schema-upgrade path so release verification catches missing-column failures before publish.
+
+### Changed
+- Archived and synced OpenSpec change `2026-03-20-add-effectiveness-schema-upgrade` into the main memory effectiveness specification.
+
+---
+
 ## [0.1.5] - 2026-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lancedb-opencode-pro",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.26.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to `0.1.6` and update `CHANGELOG.md` for the schema-upgrade patch released via PR #8.
- No functional code changes — this commit only carries the release metadata.

## Verification
- `docker compose build --no-cache && docker compose up -d`
- `docker compose exec app npm run verify`

## Release Checklist
- [x] Fix merged (PR #8)
- [x] Changelog and version updated
- [x] Verification passed
- [ ] PR merged
- [ ] Tag created (`v0.1.6`)
- [ ] Published to npm (`npm publish`)