### PR TITLE
fix: memories table schema migration for v0.1.x → v0.2.x upgrade path (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.2.1] - 2026-03-21
+
+### Fixed
+
+- Schema migration: databases created with v0.1.x now automatically receive the `lastRecalled`, `recallCount`, and `projectCount` columns on first startup with v0.2.x. Without this patch, any existing database would fail with a LanceDB schema error (`No field named "lastRecalled"`) on every query.
+
+---
+
 ## [0.2.0] - 2026-03-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",

--- a/src/store.ts
+++ b/src/store.ts
@@ -105,6 +105,7 @@ export class MemoryStore {
       await this.eventTable.delete("id = '__bootstrap__'");
     }
 
+    await this.ensureMemoriesTableCompatibility();
     await this.ensureEventTableCompatibility();
 
     await this.ensureIndexes();
@@ -590,6 +591,37 @@ export class MemoryStore {
     } catch (error) {
       this.indexState.fts = false;
       this.indexState.ftsError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  private async ensureMemoriesTableCompatibility(): Promise<void> {
+    const table = this.requireTable();
+    const schema = await table.schema();
+    const fieldNames = new Set(schema.fields.map((field) => field.name));
+
+    const missing: Array<{ name: string; valueSql: string }> = [];
+    if (!fieldNames.has("lastRecalled")) {
+      missing.push({ name: "lastRecalled", valueSql: "CAST(0 AS BIGINT)" });
+    }
+    if (!fieldNames.has("recallCount")) {
+      missing.push({ name: "recallCount", valueSql: "CAST(0 AS INT)" });
+    }
+    if (!fieldNames.has("projectCount")) {
+      missing.push({ name: "projectCount", valueSql: "CAST(0 AS INT)" });
+    }
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    try {
+      await table.addColumns(missing);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      const names = missing.map((col) => col.name).join(", ");
+      throw new Error(
+        `Failed to patch ${TABLE_NAME} schema for columns [${names}]: ${reason}`,
+      );
     }
   }
 

--- a/test/foundation/foundation.test.ts
+++ b/test/foundation/foundation.test.ts
@@ -10,6 +10,7 @@ import {
   createTestStore,
   createVector,
   seedLegacyEffectivenessEventsTable,
+  seedLegacyMemoriesTable,
 } from "../setup.js";
 
 test("write-read persistence keeps field integrity across multiple scopes", async () => {
@@ -297,6 +298,34 @@ test("store init patches legacy effectiveness_events schema before writing recal
     assert.ok(patchedEvent);
     assert.equal(patchedEvent?.type, "recall");
     assert.equal(patchedEvent?.source, "manual-search");
+  } finally {
+    await cleanupDbPath(dbPath);
+  }
+});
+
+test("store init patches legacy memories schema by adding lastRecalled recallCount and projectCount", async () => {
+  const dbPath = await createTempDbPath();
+
+  try {
+    await seedLegacyMemoriesTable(dbPath);
+    const { store } = await createTestStore(dbPath);
+
+    const results = await store.search({
+      query: "legacy memory",
+      queryVector: createVector(384, 0.5),
+      scopes: ["project:legacy"],
+      limit: 5,
+      vectorWeight: 0.7,
+      bm25Weight: 0.3,
+      minScore: 0,
+    });
+
+    assert.equal(results.length, 1);
+    const record = results[0].record;
+    assert.equal(record.id, "legacy-memory-1");
+    assert.equal(record.lastRecalled, 0, "patched column should default to 0");
+    assert.equal(record.recallCount, 0, "patched column should default to 0");
+    assert.equal(record.projectCount, 0, "patched column should default to 0");
   } finally {
     await cleanupDbPath(dbPath);
   }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -36,6 +36,26 @@ export async function cleanupDbPath(dbPath: string): Promise<void> {
   }
 }
 
+export async function seedLegacyMemoriesTable(dbPath: string, scope = "project:legacy"): Promise<void> {
+  const lancedb = await import("@lancedb/lancedb");
+  const connection = await lancedb.connect(dbPath);
+  await connection.createTable("memories", [
+    {
+      id: "legacy-memory-1",
+      text: "Legacy memory without usage tracking fields",
+      vector: Array.from({ length: DEFAULT_VECTOR_DIM }, () => 0.1),
+      category: "fact",
+      scope,
+      importance: 0.5,
+      timestamp: 1_000,
+      schemaVersion: 1,
+      embeddingModel: "test-embedding-model",
+      vectorDim: DEFAULT_VECTOR_DIM,
+      metadataJson: "{}",
+    },
+  ]);
+}
+
 export async function seedLegacyEffectivenessEventsTable(dbPath: string, scope = "project:legacy"): Promise<void> {
   const lancedb = await import("@lancedb/lancedb");
   const connection = await lancedb.connect(dbPath);


### PR DESCRIPTION
## Problem

After upgrading from v0.1.x to v0.2.0, any existing database fails immediately with:

```
Schema error: No field named 'lastRecalled'. Valid fields are scope, importance, timestamp, schemaVersion, vectorDim, id, text, vector, category, embeddingModel, metadataJson.
```

## Root Cause

v0.2.0 added three new fields to every memory record (`lastRecalled`, `recallCount`, `projectCount`) and updated `readByScopes()` to SELECT them. However, unlike the `effectiveness_events` table which already had `ensureEventTableCompatibility()` to patch missing columns on init, there was no equivalent for the `memories` table. Existing v0.1.x databases simply don't have those columns.

## Fix

- Add `ensureMemoriesTableCompatibility()` using the same `addColumns()` pattern as `ensureEventTableCompatibility()`
- Call it from `init()` after the memories table is opened, before `ensureIndexes()`
- New columns get `CAST(0 AS BIGINT/INT)` as their SQL default, so all legacy records read back with value `0`
- Add `seedLegacyMemoriesTable()` test helper and a new foundation test that seeds a v0.1.x-style DB (no usage tracking columns) and verifies the three fields are readable after migration

## Verification

- Foundation tests: 11/11 (new test 9 covers the migration path)
- `npm run verify`: foundation 11/11, regression 18/18, retrieval 2/2