### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
-## [0.2.2] - 2026-03-21
+## [0.2.3] - 2026-03-24
 
 ### Changed
 
 - Upgraded `@lancedb/lancedb` from `0.26.2` to `0.27.1` for improved hybrid search pre-filtering and native binding compatibility (napi-rs v3).
+
+### Added
+
+- `dependency-update.yml` workflow: weekly scheduled check for LanceDB version updates with compatibility testing.
+- `verify-matrix` job in CI: Node.js 20 and Node.js 22 compatibility testing.
+- `docs/lancedb-upgrades.md`: LanceDB upgrade history and verification checklist.
+- LanceDB version tracking section in CHANGELOG.md.
+
+### CI/CD
+
+- Dockerfile now supports `NODE_VERSION` build argument for matrix testing.
+- `docker-compose.ci.yml` passes `NODE_VERSION` to Docker build.
+
+---
+
+## [0.2.2] - 2026-03-21
 
 ### Fixed
 

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/design.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/design.md
@@ -1,0 +1,230 @@
+## Context
+
+### Current State
+- Project uses `@lancedb/lancedb@0.26.2` (released 2026-02-09)
+- Latest stable version is `0.27.1` (released 2026-03-20)
+- No automated dependency update monitoring exists
+- Version drift of ~6weeks with accumulated fixes and improvements
+
+### LanceDB API Usage in Project
+The project's `src/store.ts` uses the following LanceDB APIs:
+
+| API | Usage | Risk Level |
+|-----|-------|------------|
+| `connect(dbPath)` | Database connection | Low |
+| `openTable(name)` | Open existing table | Low |
+| `createTable(name, rows)` | Create new table | Low |
+| `table.add(rows)` | Insert records | Medium |
+| `table.delete(filter)` | Delete records | Low |
+| `table.query().where().select().limit().toArray()` | Query chain | Medium |
+| `table.createIndex(column, options)` | Create vector/FTS index | Medium |
+| `table.schema()` | Get table schema | Low |
+| `table.addColumns(transforms)` | Schema migration | Medium |
+
+### LanceDB 0.27.x Key Changes (Upstream)
+- **napi-rs v3** - Native binding upgrade (Node.js)
+- **Bug fix**: Pre-filtering on hybrid search (#3096)
+- **Bug fix**: Cast error propagation in `add()` (#3075)
+- **Performance**: Parallel inserts for local tables (#3062)
+- **Feature**: `fast_search` parity between vector and FTS (#3091)
+
+## Goals / Non-Goals
+
+**Goals:**
+1. Update LanceDB dependency to `0.27.1` with zero breaking changes to plugin functionality
+2. Verify all existing API usage patterns remain compatible
+3. Establish automated dependency monitoring to prevent future drift
+4. Document upgrade verification evidence for reproducibility
+
+**Non-Goals:**
+1. Adopting new LanceDB features (parallel inserts, `fast_search`) - deferred to future changes
+2. Modifying existing LanceDB API usage patterns - maintain current interface
+3. Performance benchmarking comparison - out of scope for this upgrade
+4. Multi-platform native binding testing beyond CI matrix
+
+## Decisions
+
+### Decision 1: Dependency Version Strategy
+**Choice**: Use caret version range `^0.27.1` (same pattern as current)
+
+**Rationale**:
+- Consistent with existing versioning strategy (`^0.26.2`)
+- Semver for `0.x` versions restricts updates to same minor (`>=0.27.1 <0.28.0`)
+- Package-lock.json pins exact version for reproducible builds
+- Allows future patch updates (e.g., `0.27.2`) without manual intervention
+
+**Alternatives Considered**:
+- ~~Exact version `0.27.1`~~ - Too restrictive, misses patch fixes
+- ~~Tilde version `~0.27.1`~~ - Unnecessary restriction to patch updates only
+
+### Decision 2: Upgrade Verification Phases
+**Choice**: Three-phase verification (Local → Docker → Matrix)
+
+**Phases**:
+1. **Local Verification**: `npm run verify:full` on developer machine
+2. **Docker Verification**: `docker compose build --no-cache && npm run verify:full`
+3. **CI Matrix**: Node.js 20 + Node.js 22 across Linux x64/arm64
+
+**Rationale**:
+- Catches issues early with progressive verification stages
+- Docker isolation ensures clean environment testing
+- Matrix testing validates native binding compatibility
+
+**Alternatives Considered**:
+- ~~Single-phase local-only verification~~ - May miss platform-specific issues
+- ~~Direct merge to main~~ - Too risky without staged verification
+
+### Decision 3: CI/CD Enhancement Architecture
+**Choice**: Separate workflow file for dependency monitoring
+
+**Structure**:
+```
+.github/workflows/
+├── ci.yml                    # Existing (verify, benchmark-latency, verify-full-release)
+└── dependency-update.yml      # New (check-lancedb-update, test-latest-lancedb)
+```
+
+**Rationale**:
+- Separation of concerns: CI vs dependency monitoring
+- Different triggers: PR/push vs weekly schedule
+- Independent failure handling
+- Easier to enable/disable independently
+
+**Alternatives Considered**:
+- ~~Add jobs to existing ci.yml~~ - Would mix concerns, harder to maintain
+- ~~External dependency scanning service~~ - Overkill for single dependency focus
+
+### Decision 4: High-Risk API Verification
+**Choice**: Targeted test cases for medium-risk APIs
+
+| API | Test Focus |
+|-----|------------|
+| `table.add()` | Cast error handling validation |
+| `createIndex("text")` | FTS index creation success |
+| `addColumns()` | SQL expression compatibility |
+
+**Rationale**:
+- Existing tests (`test:foundation`, `test:regression`) cover happy paths
+- Additional verification for known upstream changes (cast errors, FTS)
+- No new test infrastructure needed
+
+**Alternatives Considered**:
+- ~~Comprehensive new test suite~~ - YAGNI, existing tests sufficient with minor additions
+- ~~Skip targeted verification~~ - Risk of regression medium-risk APIs
+
+### Decision 5: Documentation Strategy
+**Choice**: CHANGELOG.md entry + version tracking spec
+
+**Rationale**:
+- CHANGELOG.md is standard location for version changes
+- OpenSpec spec creates audit trail for dependency requirements
+- Provides reference for future upgrades
+
+**Alternatives Considered**:
+- ~~Separate UPGRADE.md~~ - Redundant with CHANGELOG.md
+- ~~Inline comments only~~ - Not discoverable enough
+
+## Risks / Trade-offs
+
+### Risk 1: Native Binding Compatibility
+**Risk**: napi-rs v2 → v3 may cause issues on some platforms
+
+**Mitigation**:
+- CI matrix tests Node 20/22 on ubuntu-latest
+- Docker build uses `--no-cache` for clean native binding compilation
+- If issues arise: fallback to specific platform-specific packages
+
+### Risk 2: FTS Index API Changes
+**Risk**: Full-text search index creation may have changed in 0.27.x
+
+**Mitigation**:
+- Existing defensive code checks `Index.fts` availability
+- `test:regression` covers FTS search functionality
+- Manual verification of FTS index creation before merge
+
+### Risk 3: Database File Compatibility
+**Risk**: Existing LanceDB database files may not be readable by new version
+
+**Mitigation**:
+- LanceDB maintains backward compatibility for local databases
+- Schema migration (`ensureMemoriesTableCompatibility`) handles column additions
+- Test with real database files before merge
+
+### Risk 4: CI Time Increase
+**Risk**: Additional matrix jobs increase CI runtime
+
+**Mitigation**:
+- Matrix only runs on PR/push to main, not on every commit
+- Dependency check is weekly, not per-PR
+- Cost acceptable for dependency safety
+
+## Migration Plan
+
+### Phase 1: Preparation (Local)
+```bash
+# 1. Create feature branch
+git checkout -b upgrade/lancedb-0.27
+
+# 2. Backup existing data
+cp -r ~/.opencode/memory/lancedb ~/.opencode/memory/lancedb.backup
+
+# 3. Update dependency
+# Edit package.json: "@lancedb/lancedb": "^0.27.1"
+npm install
+
+# 4. Run local verification
+npm run verify:full
+```
+
+### Phase 2: Docker Verification
+```bash
+# 5. Clean Docker build
+docker compose build --no-cache && docker compose up -d
+
+# 6. Run all tests in container
+docker compose exec app npm run verify:full
+
+# 7. Test with real data
+docker compose exec app npm run test:e2e
+```
+
+### Phase 3: CI Verification
+```bash
+# 8. Push branch for CI
+git push origin upgrade/lancedb-0.27
+
+# 9. Monitor CI matrix results
+# - Node 20 + Node 22
+# - Ubuntu latest (x64)
+# - Docker clean build
+```
+
+### Phase 4: Merge
+```bash
+# 10. After all checks pass
+# - Update CHANGELOG.md
+# - Merge to main
+# - Verify production tag builds
+```
+
+### Rollback Strategy
+If issues discovered post-merge:
+
+1. **Immediate**: Revert commit on main branch
+2. **Dependency**: Downgrade to `^0.26.2` in package.json
+3. **Verification**: Re-run full test suite on downgraded version
+4. **Data**: No data migration needed (backward compatible)
+5. **Timeline**: Maximum 1 hour to revert and redeploy
+
+## Open Questions
+
+1. ~~Should we document supported Node.js version range?~~ **Resolved**: Node 22+ per package.json `engines`
+
+2. ~~Should we add Windows/macOS to CI matrix?~~ **Decision**: Defer to future - Linux x64 is primary deployment target
+
+3. **Should we pin exact LanceDB version in production?**
+   - Current: `^0.27.1` allows patch updates
+   - Alternative: `0.27.1` exact version
+   - **Recommendation**: Keep caret range, rely on package-lock for reproducibility
+
+4. ~~When should we adopt `fast_search` feature?~~ **Decision**: Defer - not needed for current use case

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/proposal.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The project currently uses `@lancedb/lancedb@0.26.2` (released 2026-02-09), which is behind the latest stable version `0.27.1` (released 2026-03-20). This upgrade brings important bug fixes for hybrid search pre-filtering, performance improvements for parallel inserts, and native binding upgrades (napi-rs v2 → v3). Additionally, a systematic dependency upgrade verification workflow is needed to prevent future version drift and ensure timely security updates.
+
+## What Changes
+
+### Dependency Version Update
+- Update `@lancedb/lancedb` from `^0.26.2` to `^0.27.1` in `package.json` and `package-lock.json`
+- Verify compatibility with all existing LanceDB API usage patterns in `src/store.ts`
+
+### Breaking Changes (Upstream) - **NOT AFFECTING THIS PROJECT**
+- LanceDB 0.27.0 has breaking changes for Rust API `RecordBatchReader` handling, but this project uses Node.js bindings which remain compatible
+
+### New Features Available (Optional Future Adoption)
+- Parallel inserts for large datasets (automatically handled by LanceDB)
+- `fast_search` parameter for improved query performance
+- Improved cast error propagation in `add()` method
+
+### Bug Fixes Benefiting This Project
+- Pre-filtering fix for hybrid search (v0.27.1)
+- Graceful handling of empty result sets in hybrid search
+- Fixed non-stopping dataset version check
+
+### CI/CD Enhancement
+- New GitHub Actions workflow for dependency update monitoring (`dependency-update.yml`)
+- Weekly scheduled check for LanceDB version updates
+- Automated compatibility testing with latest dependency versions
+- Issue creation for available updates that pass compatibility tests
+
+## Capabilities
+
+### New Capabilities
+
+- `dependency-upgrade-workflow`: Automated weekly checks for LanceDB version updates with compatibility verification and issue creation for reviewable updates
+- `lancedb-version-tracking`: Documentation and tracking of LanceDB version requirements, compatibility notes, and upgrade history
+
+### Modified Capabilities
+
+- `memory-provider-config`: Update dependency requirements from `@lancedb/lancedb@^0.26.2` to `@lancedb/lancedb@^0.27.1` in configuration specifications
+- `memory-validation-harness`: Extend test coverage to verify LanceDB 0.27.x API compatibility, particularly for FTS index creation and `addColumns()` schema migration
+
+## Impact
+
+### Code Changes
+- `package.json`: Version bump from `^0.26.2` to `^0.27.1`
+- `package-lock.json`: Regenerated with new dependency tree
+- `.github/workflows/ci.yml`: New `dependency-audit` and `verify-matrix` jobs
+- `.github/workflows/dependency-update.yml`: New workflow for automated dependency monitoring
+- `CHANGELOG.md`: Document the upgrade and verification results
+
+### API Compatibility
+- **Low Risk**: Core APIs (`connect`, `openTable`, `createTable`, `delete`, `query`, `schema`) have no breaking changes for Node.js
+- **Medium Risk**: `table.add()` has improved cast error handling - needs verification
+- **Medium Risk**: `createIndex()` FTS configuration API may need validation
+- **Medium Risk**: `addColumns()` SQL expression syntax needs compatibility testing
+
+### Test Changes
+- Add verification for FTS index creation with LanceDB 0.27.x
+- Add verification for schema migration (`addColumns`) with new LanceDB version
+- Add verification for hybrid search (vector + BM25) query results
+- Add Node.js version matrix testing (Node 20, 22)
+
+### Dependencies
+- `@lancedb/lancedb`: `0.26.2` → `0.27.1`
+- Native bindings: `napi-rs v2` → `napi-rs v3` (handled by LanceDB package)
+- New optional peer dependency: `apache-arrow` version range validation (already compatible)
+
+### Documentation
+- `README.md`: Update supported versions if needed
+- `CHANGELOG.md`: Add upgrade entry with verification evidence
+- `docs/release-readiness.md`: Update dependency verification requirements

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/dependency-upgrade-workflow/spec.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/dependency-upgrade-workflow/spec.md
@@ -1,0 +1,54 @@
+# dependency-upgrade-workflow Specification
+
+## Purpose
+Automated weekly checks for LanceDB dependency version updates with compatibility verification and issue creation for manageable upgrades.
+
+## ADDED Requirements
+
+### Requirement: Weekly dependency version check
+The project MUST provide a scheduled GitHub Actions workflow that checks for available LanceDB version updates on a weekly basis.
+
+#### Scenario: Weekly check runs on schedule
+- **WHEN** the scheduled weekly check runs
+- **THEN** the workflow compares current LanceDB version in package.json against the latest published version on npm
+
+#### Scenario: Dependency check reports status
+- **WHEN** the dependency version comparison completes
+- **THEN** the workflow outputs a status indicating whether an update is available and the version delta
+
+### Requirement: Compatibility verification with latest version
+The project MUST verify compatibility before recommending an upgrade by running the full test suite against the latest available version.
+
+#### Scenario: Automatic compatibility test runs
+- **WHEN** an update is available
+- **THEN** the workflow builds and tests with the latest LanceDB version in an isolated Docker environment
+
+#### Scenario: Compatibility test passes
+- **WHEN** all verification tests pass with the latest version
+- **THEN** the workflow proceeds to create an update issue
+
+#### Scenario: Compatibility test fails
+- **WHEN** any verification test fails with the latest version
+- **THEN** the workflow reports the failure without creating an update issue
+
+### Requirement: Automated issue creation for upgrades
+The project MUST create a GitHub issue when an available update passes compatibility testing.
+
+#### Scenario: Issue created for compatible update
+- **WHEN** an update is available and passes compatibility testing
+- **THEN** the workflow creates a GitHub issue with change details, verification evidence, and an actionable checklist
+
+#### Scenario: Duplicate issue prevention
+- **WHEN** an update issue for the same dependency already exists and is open
+- **THEN** the workflow does NOT create a duplicate issue
+
+### Requirement: Dependency audit integration
+The project MUST include security vulnerability auditing as part of the dependency check workflow.
+
+#### Scenario: Security audit runs during dependency check
+- **WHEN** the weekly dependency check runs
+- **THEN** the workflow executes `npm audit` to check for known vulnerabilities
+
+#### Scenario: Security findings reported
+- **WHEN** `npm audit` finds moderate or higher severity vulnerabilities
+- **THEN** the workflow annotation includes the vulnerability details

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/lancedb-version-tracking/spec.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/lancedb-version-tracking/spec.md
@@ -1,0 +1,42 @@
+# lancedb-version-tracking Specification
+
+## Purpose
+Documentation and tracking of LanceDB version requirements, compatibility notes, and upgrade history for reproducible dependency management.
+
+## ADDED Requirements
+
+### Requirement: Version history documentation
+The project MUST maintain a version history section in CHANGELOG.md that documents each LanceDB dependency change with version numbers, upgrade reasons, and verification status.
+
+#### Scenario: Changelog entry for dependency upgrade
+- **WHEN** LanceDB dependency version is changed
+- **THEN** CHANGELOG.md includes an entry with the version change, reason, and verification evidence reference
+
+#### Scenario: Version history queryable
+- **WHEN** a developer or operator reviews the changelog
+- **THEN** the LanceDB version history is discoverable with date, version, and upgrade context
+
+### Requirement: Compatibility notes maintenance
+The project MUST maintain compatibility notes for each LanceDB version change, documenting any API usage considerations and tested platforms.
+
+#### Scenario: Compatibility notes for new version
+- **WHEN** upgrading to a new LanceDB version
+- **THEN** the upgrade task documents tested Node.js versions, native binding compatibility, and API usage verification results
+
+#### Scenario: Breaking change documentation
+- **WHEN** a LanceDB version has breaking changes relevant to this project
+- **THEN** the compatibility notes explicitly document the breaking change and required code adjustments
+
+### Requirement: Supported version range documentation
+The project MUST document the supported LanceDB version range and minimum required version in the README.md.
+
+#### Scenario: Version requirement documented
+- **WHEN** a user or contributor reviews README.md
+- **THEN** the LanceDB version requirement is clearly stated with minimum supported version
+
+### Requirement: Upgrade verification evidence retention
+The project MUST retain verification evidence (CI run links, test results) for each successful dependency upgrade.
+
+#### Scenario: CI run linked from changelog
+- **WHEN** a dependency upgrade is merged
+- **THEN** the CHANGELOG.md entry includes reference to the successful CI run that verified compatibility

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/memory-provider-config/spec.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/memory-provider-config/spec.md
@@ -1,0 +1,64 @@
+# memory-provider-config Specification (Delta)
+
+## Purpose
+TBD - created by archiving change add-lancedb-memory-provider. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Memory provider configuration contract
+The system MUST support a memory configuration contract in sidecar config and environment variables with provider id, storage path, embedding settings, and retrieval settings, including both `ollama` and `openai` embedding providers and phase-1 ranking controls (`rrfK`, recency toggle, recency half-life hours, and importance weight).
+
+#### Scenario: Valid provider configuration is loaded
+- **WHEN** memory config contains `provider = "lancedb-opencode-pro"` with valid `dbPath`, `embedding`, and `retrieval` fields
+- **THEN** the provider configuration is accepted and initialized without fallback
+
+#### Scenario: Missing optional retrieval values uses defaults
+- **WHEN** `memory.retrieval` omits optional mode, threshold, or phase-1 ranking control fields
+- **THEN** the system applies documented defaults including `mode = hybrid`, `rrfK = 60`, recency boost enabled with a conservative half-life default, and moderate importance weighting
+
+#### Scenario: Embedding provider defaults to ollama
+- **WHEN** `memory.embedding.provider` is omitted
+- **THEN** the system defaults embedding provider to `ollama` to preserve backward compatibility
+
+#### Scenario: Environment variable overrides embedding provider settings
+- **WHEN** OpenAI or Ollama embedding settings are provided in supported environment variables
+- **THEN** environment variable values override sidecar configuration according to documented precedence
+
+### Requirement: Default storage path behavior
+The system MUST default memory storage path to `~/.opencode/memory/lancedb` when `memory.dbPath` is not explicitly configured, and the project MUST provide a supported verification path for operators to inspect the active storage location.
+
+#### Scenario: No dbPath provided
+- **WHEN** user enables memory provider without defining `memory.dbPath`
+- **THEN** storage is initialized under `~/.opencode/memory/lancedb`
+
+#### Scenario: Operator verifies configured storage path
+- **WHEN** an operator runs the documented verification flow for the active environment
+- **THEN** the operator can inspect the resolved storage path and confirm that the provider initialized the expected database location
+
+### Requirement: Embedding compatibility validation
+The system MUST validate embedding model compatibility for stored vectors and prevent unsafe mixed-dimension vector retrieval, and the project MUST provide executable validation that surfaces incompatible-vector conditions before release.
+
+#### Scenario: Embedding model dimension changes
+- **WHEN** configured embedding model dimension differs from existing stored vector metadata
+- **THEN** the system blocks unsafe vector mixing and provides a migration/reindex guidance signal
+
+#### Scenario: Validation workflow detects incompatible vectors
+- **WHEN** maintainers run the foundation validation workflow against mixed-dimension test data
+- **THEN** the workflow reports incompatible vectors and fails the compatibility check
+
+## ADDED Requirements
+
+### Requirement: LanceDB version compatibility
+The provider MUST be compatible with LanceDB versions specified in package.json dependencies, and the project MUST verify compatibility through automated CI testing before release.
+
+#### Scenario: New LanceDB version compatibility verified
+- **WHEN** LanceDB dependency version is updated
+- **THEN** CI tests verify all storage operations (connect, openTable, createTable, add, delete, query, createIndex, schema, addColumns) pass with the new version
+
+#### Scenario: Native binding compatibility tested
+- **WHEN** CI runs verification on Node.js 20 and Node.js 22
+- **THEN** native bindings for LanceDB function correctly across supported Node.js versions
+
+#### Scenario: Minimum compatible version documented
+- **WHEN** a user or contributor reviews package.json
+- **THEN** the minimum supported LanceDB version is specified with caret semver range allowing compatible patch and minor updates

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/memory-validation-harness/spec.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/specs/memory-validation-harness/spec.md
@@ -1,0 +1,87 @@
+# memory-validation-harness Specification (Delta)
+
+## Purpose
+TBD - created by archiving change add-memory-validation-harness. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Layered validation workflows
+The project MUST provide executable validation workflows separated into foundation correctness, regression safety, retrieval quality, and performance benchmarking layers.
+
+#### Scenario: Developer runs foundation validation
+- **WHEN** a developer executes the foundation validation workflow
+- **THEN** the project verifies core storage correctness behaviors including persistence, scope isolation, and vector compatibility without requiring benchmark-scale data generation
+
+#### Scenario: Developer runs benchmark validation
+- **WHEN** a developer executes the benchmark validation workflow
+- **THEN** the project reports retrieval-quality or latency metrics separately from the core pass/fail correctness suite
+
+### Requirement: Docker-aligned verification entrypoints
+The project MUST expose validation entrypoints that can be executed through the documented Docker workflow.
+
+#### Scenario: Containerized release-readiness validation
+- **WHEN** an operator starts the documented Docker environment and invokes the validation commands from inside the application container
+- **THEN** the project runs the same supported verification workflows used for release-readiness checks
+
+### Requirement: Acceptance evidence mapping
+The project MUST map executable validation workflows to the documented acceptance and validation checklist items.
+
+#### Scenario: Release checklist review
+- **WHEN** a maintainer reviews release readiness after running validation workflows
+- **THEN** the maintainer can determine which acceptance items are covered by automated evidence and which remain manual or unresolved
+
+### Requirement: Effectiveness reporting workflow
+The project MUST provide a documented workflow for generating long-memory effectiveness summaries from recorded runtime events in the supported local or Docker verification environment.
+
+#### Scenario: Operator runs effectiveness report in Docker workflow
+- **WHEN** an operator starts the documented Docker environment and invokes the effectiveness reporting entrypoint
+- **THEN** the project generates a machine-readable effectiveness summary suitable for release review or tuning analysis
+
+### Requirement: Effectiveness evidence in release review
+The project MUST document how effectiveness metrics and feedback counts are reviewed alongside existing retrieval and latency validation evidence.
+
+#### Scenario: Maintainer reviews release readiness with effectiveness data
+- **WHEN** a maintainer evaluates release readiness after running validation and reporting workflows
+- **THEN** the maintainer can inspect both offline retrieval metrics and online effectiveness summaries in one documented review path
+
+### Requirement: Low-feedback review guidance
+The project MUST document a validation and review workflow for low-feedback environments that combines runtime summaries, proxy metrics, and sampled audits.
+
+#### Scenario: Maintainer reviews release readiness with sparse user feedback
+- **WHEN** maintainers review long-memory effectiveness and explicit feedback counts are sparse
+- **THEN** the documented workflow instructs them to review proxy metrics and sampled audits instead of relying on feedback totals alone
+
+### Requirement: Proxy-metric evidence mapping
+The project MUST map low-feedback proxy metrics and sample-audit expectations into the effectiveness review process.
+
+#### Scenario: Team evaluates whether memory reduced interaction cost
+- **WHEN** the team asks whether long memory helped in real OpenCode usage
+- **THEN** the review path includes evidence for reduced repeated context, reduced clarification burden, reduced manual rescue behavior, or stable correction-signal rates
+
+## ADDED Requirements
+
+### Requirement: Dependency upgrade verification
+The project MUST verify LanceDB dependency upgrades through a dedicated CI workflow that tests native binding compatibility and API usage correctness.
+
+#### Scenario: CI runs dependency compatibility matrix
+- **WHEN** a LanceDB dependency change is proposed
+- **THEN** CI tests verify compatibility on Node.js 20 and Node.js 22 across Linux platforms
+
+#### Scenario: FTS index creation verified
+- **WHEN** CI runs foundation validation after LanceDB upgrade
+- **THEN** the test suite explicitly verifies full-text search index creation succeeds
+
+#### Scenario: Schema migration verified
+- **WHEN** CI runs foundation validation after LanceDB upgrade
+- **THEN** the test suite explicitly verifies `addColumns()` schema migration operations succeed
+
+### Requirement: Node.js version matrix testing
+The project MUST run verification tests on multiple Node.js versions to ensure native binding compatibility across supported runtime versions.
+
+#### Scenario: Matrix test includes Node 20 and Node 22
+- **WHEN** CI runs pull request or main branch verification
+- **THEN** the test matrix includes Node.js 20 and Node.js 22
+
+#### Scenario: Native dependency compilation succeeds
+- **WHEN** CI builds on Node.js 20 and Node.js 22
+- **THEN** LanceDB native bindings compile and load successfully on both versions

--- a/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/tasks.md
+++ b/openspec/changes/archive/2026-03-24-upgrade-lancedb-dependency/tasks.md
@@ -1,0 +1,51 @@
+## 1. Dependency Update
+
+- [x] 1.1 Update `@lancedb/lancedb` version in `package.json` from `^0.26.2` to `^0.27.1`
+- [x] 1.2 Run `npm install` to update `package-lock.json`
+- [x] 1.3 Run `npm run verify:full` locally to verify initial compatibility
+- [x] 1.4 Run Docker verification: `docker compose build --no-cache && docker compose up -d && docker compose exec app npm run verify:full`
+- [x] 1.5 Document local verification results in CHANGELOG.md
+
+## 2. CI/CD Workflow Enhancement
+
+- [x] 2.1 Create `.github/workflows/dependency-update.yml` with weekly scheduled check for LanceDB updates
+- [x] 2.2 Add dependency audit step to check for known vulnerabilities with `npm audit --audit-level=moderate`
+- [x] 2.3 Add version drift detection to compare current vs latest LanceDB version
+- [x] 2.4 Add compatibility test job that builds and tests with latest version on schedule
+- [x] 2.5 Add issue creation step when compatible update is available
+
+## 3. CI Matrix Enhancement
+
+- [x] 3.1 Add `verify-matrix` job to `.github/workflows/ci.yml` with Node.js 20 and Node.js 22
+- [x] 3.2 Configure matrix fail-fast: false to run all versions regardless of individual failures
+- [x] 3.3 Ensure Docker build passes `NODE_VERSION` build argument for matrix testing
+
+## 4. Test Enhancement
+
+- [x] 4.1 Review `test/foundation/foundation.test.ts` for FTS index test coverage
+- [x] 4.2 Verify `test/regression/plugin.test.ts` covers `table.add()` cast error handling
+- [x] 4.3 Verify schema migration tests cover `addColumns()` with SQL expressions
+- [x] 4.4 Run `npm run test:foundation` and confirm all tests pass with LanceDB 0.27.1
+- [x] 4.5 Run `npm run test:regression` and confirm all tests pass with LanceDB 0.27.1
+- [x] 4.6 Run `npm run test:retrieval` to verify hybrid search functionality
+- [x] 4.7 Run `npm run test:effectiveness` to verify event persistence
+
+## 5. Documentation Update
+
+- [x] 5.1 Update `CHANGELOG.md` with LanceDB upgrade entry and verification evidence
+- [x] 5.2 Add LanceDB version tracking section to CHANGELOG.md
+- [x] 5.3 Update README.md if dependency instructions need modification
+- [x] 5.4 Create or update `docs/lancedb-upgrades.md` with upgrade history and compatibility notes
+
+## 6. Verification and Merge
+
+- [x] 6.1 Push branch and monitor CI matrix results (Node 20, Node 22)
+- [x] 6.2 Review all CI checks: verify, dependency-audit, verify-matrix
+- [x] 6.3 Address any CI failures and re-run verification
+- [x] 6.4 Confirm all test suites pass (foundation, regression, retrieval, effectiveness)
+- [ ] 6.5 Merge to main branch after all checks pass
+- [ ] 6.6 Verify release tag build with `npm run release:check`
+
+## 7. OpenSpec Archive
+
+- [x] 7.1 Run `/openspec-verify` to confirm implementation matches specs

--- a/openspec/specs/dependency-upgrade-workflow/spec.md
+++ b/openspec/specs/dependency-upgrade-workflow/spec.md
@@ -1,0 +1,53 @@
+# dependency-upgrade-workflow Specification
+
+## Purpose
+TBD - created by archiving change upgrade-lancedb-dependency. Update Purpose after archive.
+## Requirements
+### Requirement: Weekly dependency version check
+The project MUST provide a scheduled GitHub Actions workflow that checks for available LanceDB version updates on a weekly basis.
+
+#### Scenario: Weekly check runs on schedule
+- **WHEN** the scheduled weekly check runs
+- **THEN** the workflow compares current LanceDB version in package.json against the latest published version on npm
+
+#### Scenario: Dependency check reports status
+- **WHEN** the dependency version comparison completes
+- **THEN** the workflow outputs a status indicating whether an update is available and the version delta
+
+### Requirement: Compatibility verification with latest version
+The project MUST verify compatibility before recommending an upgrade by running the full test suite against the latest available version.
+
+#### Scenario: Automatic compatibility test runs
+- **WHEN** an update is available
+- **THEN** the workflow builds and tests with the latest LanceDB version in an isolated Docker environment
+
+#### Scenario: Compatibility test passes
+- **WHEN** all verification tests pass with the latest version
+- **THEN** the workflow proceeds to create an update issue
+
+#### Scenario: Compatibility test fails
+- **WHEN** any verification test fails with the latest version
+- **THEN** the workflow reports the failure without creating an update issue
+
+### Requirement: Automated issue creation for upgrades
+The project MUST create a GitHub issue when an available update passes compatibility testing.
+
+#### Scenario: Issue created for compatible update
+- **WHEN** an update is available and passes compatibility testing
+- **THEN** the workflow creates a GitHub issue with change details, verification evidence, and an actionable checklist
+
+#### Scenario: Duplicate issue prevention
+- **WHEN** an update issue for the same dependency already exists and is open
+- **THEN** the workflow does NOT create a duplicate issue
+
+### Requirement: Dependency audit integration
+The project MUST include security vulnerability auditing as part of the dependency check workflow.
+
+#### Scenario: Security audit runs during dependency check
+- **WHEN** the weekly dependency check runs
+- **THEN** the workflow executes `npm audit` to check for known vulnerabilities
+
+#### Scenario: Security findings reported
+- **WHEN** `npm audit` finds moderate or higher severity vulnerabilities
+- **THEN** the workflow annotation includes the vulnerability details
+

--- a/openspec/specs/lancedb-version-tracking/spec.md
+++ b/openspec/specs/lancedb-version-tracking/spec.md
@@ -1,0 +1,41 @@
+# lancedb-version-tracking Specification
+
+## Purpose
+TBD - created by archiving change upgrade-lancedb-dependency. Update Purpose after archive.
+## Requirements
+### Requirement: Version history documentation
+The project MUST maintain a version history section in CHANGELOG.md that documents each LanceDB dependency change with version numbers, upgrade reasons, and verification status.
+
+#### Scenario: Changelog entry for dependency upgrade
+- **WHEN** LanceDB dependency version is changed
+- **THEN** CHANGELOG.md includes an entry with the version change, reason, and verification evidence reference
+
+#### Scenario: Version history queryable
+- **WHEN** a developer or operator reviews the changelog
+- **THEN** the LanceDB version history is discoverable with date, version, and upgrade context
+
+### Requirement: Compatibility notes maintenance
+The project MUST maintain compatibility notes for each LanceDB version change, documenting any API usage considerations and tested platforms.
+
+#### Scenario: Compatibility notes for new version
+- **WHEN** upgrading to a new LanceDB version
+- **THEN** the upgrade task documents tested Node.js versions, native binding compatibility, and API usage verification results
+
+#### Scenario: Breaking change documentation
+- **WHEN** a LanceDB version has breaking changes relevant to this project
+- **THEN** the compatibility notes explicitly document the breaking change and required code adjustments
+
+### Requirement: Supported version range documentation
+The project MUST document the supported LanceDB version range and minimum required version in the README.md.
+
+#### Scenario: Version requirement documented
+- **WHEN** a user or contributor reviews README.md
+- **THEN** the LanceDB version requirement is clearly stated with minimum supported version
+
+### Requirement: Upgrade verification evidence retention
+The project MUST retain verification evidence (CI run links, test results) for each successful dependency upgrade.
+
+#### Scenario: CI run linked from changelog
+- **WHEN** a dependency upgrade is merged
+- **THEN** the CHANGELOG.md entry includes reference to the successful CI run that verified compatibility
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.2.3

Bump version to 0.2.3 and update changelog.

### Changes
- Upgraded `@lancedb/lancedb` from `0.26.2` to `0.27.1`
- Added `dependency-update.yml` workflow for weekly LanceDB checks
- Added `verify-matrix` job for Node.js 20/22 testing
- Added `docs/lancedb-upgrades.md` for upgrade history
- Archived OpenSpec change `upgrade-lancedb-dependency`

### Changelog
See [CHANGELOG.md](CHANGELOG.md) for full details.