### PR TITLE
ci: add Trivy SCA and Semgrep SAST scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           exit-code: '1'
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -47,23 +47,17 @@ jobs:
     permissions:
       security-events: write
       contents: read
+    container:
+      image: returntocorp/semgrep:1.76.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Run Semgrep SAST scan
-        uses: returntocorp/semgrep-action@v1
-        with:
-          config: |
-            p/security-audit
-            p/owasp-top-ten
-            p/cwe-top-25
-          upload: 'sarif'
-          upload-target: 'internal'
-          publish-token: 'none'
+        run: semgrep scan --sarif --config p/security-audit --config p/owasp-top-ten --config p/cwe-top-25 --output semgrep.sarif
 
       - name: Upload Semgrep results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'semgrep.sarif'


### PR DESCRIPTION
## Summary
- **SCA (Trivy)**: Filesystem scan for dependency/IaC/secrets vulnerabilities with `CRITICAL,HIGH` severity gate — blocks merge on findings
- **SAST (Semgrep)**: Pattern-based code scan with `security-audit`, `owasp-top-ten`, `cwe-top-25` rulesets — no API token required
- Both jobs output SARIF to GitHub Security tab (Code scanning)

## Why
- Detect vulnerable dependencies before they reach production
- Catch common security mispatterns in source code (OWASP Top 10, CWE Top 25)
- Results surface directly in PR checks and GitHub Security tab