### PR TITLE
ci(sca): add npm ci before Trivy scan for full dependency scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Summary
- Add `npm ci` step before Trivy scan so it can inspect actual `node_modules` rather than just `package-lock.json` metadata
- Enables Trivy to detect vulnerabilities in transitive dependencies (dependencies-of-dependencies)

## Why
Without `npm ci`, Trivy only reads `package-lock.json` metadata which has limited CVE coverage. Installing full `node_modules` allows Trivy to scan the complete dependency tree.