### PR TITLE
fix: prevent self-merge in consolidateDuplicates (issue #25)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -348,6 +348,12 @@ export class MemoryStore {
 
         const older = a.row.timestamp <= b.row.timestamp ? a.row : b.row;
         const newer = a.row.timestamp <= b.row.timestamp ? b.row : a.row;
+
+        // Skip self-merge: when timestamps are equal, both could reference the same record
+        if (older.id === newer.id) {
+          continue;
+        }
+
         const newerMeta = parseMetadata(newer.metadataJson);
 
         const mergedIntoId = newer.id;


### PR DESCRIPTION
## Summary

- Fix bug where `consolidateDuplicates` could produce self-referencing records
- When two records have identical timestamps, they could be treated as merge candidates with themselves
- Added ID check before merge to skip self-merge cases

## Changes

```diff
const older = a.row.timestamp <= b.row.timestamp ? a.row : b.row;
const newer = a.row.timestamp <= b.row.timestamp ? b.row : a.row;

+// Skip self-merge: when timestamps are equal, both could reference the same record
+if (older.id === newer.id) {
+  continue;
+}
```

Fixes #25