### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.6.2] - 2026-04-05
+
+### Added
+
+- **Index Race Condition Fix** (user-facing):
+  - Fixed TOCTOU race condition when multiple OpenCode processes start simultaneously
+  - Added `isCommitConflict()` helper to detect LanceDB retryable commit conflict errors
+  - After commit conflict, re-verify index existence before counting failure (adopt index if created by concurrent process)
+  - Added randomized jitter to retry backoff to prevent thundering-herd re-collision
+  - Added final-pass existence check after all retries exhausted
+  - Evidence:
+    - Spec: openspec/changes/archive/2026-04-05-fix-fts-index-race-condition/specs/index-retry/spec.md
+    - Code: src/store.ts (isCommitConflict, createVectorIndexWithRetry, createFtsIndexWithRetry)
+    - Tests: test/unit/index-race-condition.test.ts (6 new tests)
+    - Surface: internal-api
+
+### Changed
+
+- **Index Retry Spec Updated**:
+  - Synced delta specs to main spec `openspec/specs/index-retry/spec.md`
+  - Added 3 new requirements with 7 scenarios covering commit-conflict handling, jitter backoff, final-pass check
+
+### Documentation
+
+- Updated `docs/backlog.md` with BL-051 (FTS/Vector index concurrent-process race condition fix)
+- Updated `docs/roadmap.md` with BL-051 in P1 list
+
+---
+
 ## [0.6.1] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,14 +173,13 @@ Alternatively, install via `.tgz` release asset or build from source. See [Insta
 
 ## 🗺️ Version History
 
+- **v0.6.2**: Index Race Condition Fix (concurrent-process conflict handling, jitter backoff)
+- **v0.6.1**: Event TTL/Archival, Index Creation Resilience, Duplicate Consolidation Performance
 - **v0.6.0**: Learning Dashboard, KPI Pipeline, Feedback-Driven Ranking, Task-Type Aware Injection
 - **v0.5.0**: Memory Explanation Tools (`memory_why`, `memory_explain_recall`)
 - **v0.4.0**: Citation Model (`memory_citation`, `memory_validate_citation`)
-- **v0.3.0**: Episodic Learning Hooks
-- **v0.2.9**: Episodic Learning Tools
-- **v0.2.5**: Deduplication (`memory_consolidate`)
-- **v0.2.4**: Memory Injection Controls (budget, adaptive)
-- **v0.2.0**: Cross-project Memory Sharing (global scope)
+
+_[older versions removed - see CHANGELOG.md for full history]_
 
 See [CHANGELOG.md](CHANGELOG.md) for all changes.
 
@@ -199,5 +198,5 @@ See [CHANGELOG.md](CHANGELOG.md) for all changes.
 - **Issues**: Submit errors or requests on [GitHub Issues](https://github.com/tryweb/lancedb-opencode-pro/issues).
 - **License**: MIT License - see [LICENSE](LICENSE).
 
-**Last Updated**: 2026-03-31
-**Latest Version**: v0.6.0
+**Last Updated**: 2026-04-05
+**Latest Version**: v0.6.2

--- a/README_zh.md
+++ b/README_zh.md
@@ -166,14 +166,13 @@ docker compose exec opencode-dev npm run verify:full
 
 ## 🗺️ 版本歷史
 
+- **v0.6.2**: 修復索引競爭條件（並發衝突處理、jitter 重試）
+- **v0.6.1**: 事件 TTL/歸檔、索引建立彈性、去重複效能優化
 - **v0.6.0**: 新增學習儀表板、KPI 管線、反饋驅動排序、任務類型感知注入
 - **v0.5.0**: 新增記憶解釋工具 (`memory_why`, `memory_explain_recall`)
 - **v0.4.0**: 新增引用模型追蹤與驗證 (`memory_citation`, `memory_validate_citation`)
-- **v0.3.0**: 引入事件式學習 Hooks
-- **v0.2.9**: 引入事件式學習工具 (`task_episode_create`, `similar_task_recall` 等)
-- **v0.2.5**: 新增去重複機制 (`memory_consolidate`)
-- **v0.2.4**: 強化記憶注入控制 (支援 budget, adaptive 模式)
-- **v0.2.0**: 支援跨專案記憶共享 (global scope)
+
+_[舊版歷史請參閱 CHANGELOG.md]_
 
 完整變更日誌請參閱：[CHANGELOG.md](CHANGELOG.md)
 
@@ -192,5 +191,5 @@ docker compose exec opencode-dev npm run verify:full
 - **報告問題**: 軟體錯誤回報或功能請求，請至 [GitHub Issues](https://github.com/tryweb/lancedb-opencode-pro/issues) 提交。
 - **授權協議**: MIT License - 詳見 [LICENSE](LICENSE)。
 
-**最後更新**: 2026-03-31  
-**最新版本**: v0.6.0
+**最後更新**: 2026-04-05
+**最新版本**: v0.6.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump version to 0.6.2. See CHANGELOG.md for details.