### PR TITLE
chore: add test database directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ npm-debug.log*
 !.opencode/skills/
 !.opencode/skills/**
 
+# Test databases (LanceDB test artifacts)
+test/.test-db-*/
+
 # Agent guidelines (local development instructions for AI agents)
 AGENT.md


### PR DESCRIPTION
Add `test/.test-db-*/` pattern to prevent git from tracking LanceDB test artifact directories created during test execution.