### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.8.0] - 2026-04-09
+
+### Added
+
+- **Structured Logging via client.app.log()** (user-facing):
+  - Replaced all `console.warn`/`console.info` calls with structured logging via OpenCode SDK's `client.app.log()`
+  - Added plugin version logging on initialization
+  - Centralized logging in new `src/logger.ts` module with console fallback for non-OpenCode environments
+  - Evidence:
+    - Spec: N/A (best practice, no spec required)
+    - Code: src/logger.ts (new), src/index.ts, src/embedder.ts, src/tools/memory.ts (log calls replaced)
+    - Tests: test:foundation (31 pass), test:regression (32 pass)
+    - Surface: internal-api
+  - Fixes #77
+
+- **Test Environment Isolation Fix** (internal):
+  - Enhanced `withPatchedEnv` utility to support `undefined` values for explicit env var cleanup
+  - Fixed test isolation issue where host `LANCEDB_OPENCODE_PRO_EMBEDDING_MODEL` was leaking into test environment
+  - Evidence:
+    - Spec: N/A (test infrastructure fix)
+    - Code: test/config.test.ts, test/regression/plugin.test.ts (withPatchedEnv upgrade)
+    - Tests: test:regression (32 pass, was 31 pass 1 fail)
+    - Surface: internal-api
+
+---
+
 ## [0.7.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,13 +173,12 @@ Alternatively, install via `.tgz` release asset or build from source. See [Insta
 
 ## 🗺️ Version History
 
+- **v0.8.0**: Structured Logging via client.app.log() per OpenCode best practices, Test Environment Isolation Fix
 - **v0.7.0**: OpenCode SDK v1.3.14 Compatibility, Node 22 memory_search Race Condition Fix
 - **v0.6.3**: Index Creation Guard (defer on empty/insufficient tables, fix #70), LanceDB 0.27.2
 - **v0.6.2**: Index Race Condition Fix (concurrent-process conflict handling, jitter backoff)
 - **v0.6.1**: Event TTL/Archival, Index Creation Resilience, Duplicate Consolidation Performance
 - **v0.6.0**: Learning Dashboard, KPI Pipeline, Feedback-Driven Ranking, Task-Type Aware Injection
-- **v0.5.0**: Memory Explanation Tools (`memory_why`, `memory_explain_recall`)
-- **v0.4.0**: Citation Model (`memory_citation`, `memory_validate_citation`)
 
 _[older versions removed - see CHANGELOG.md for full history]_
 
@@ -201,4 +200,4 @@ See [CHANGELOG.md](CHANGELOG.md) for all changes.
 - **License**: MIT License - see [LICENSE](LICENSE).
 
 **Last Updated**: 2026-04-09
-**Latest Version**: v0.7.0
+**Latest Version**: v0.8.0

--- a/README_zh.md
+++ b/README_zh.md
@@ -166,13 +166,12 @@ docker compose exec opencode-dev npm run verify:full
 
 ## 🗺️ 版本歷史
 
+- **v0.8.0**: 結構化日誌 (client.app.log()) 遵循 OpenCode 最佳實踐、測試環境隔離修復
 - **v0.7.0**: OpenCode SDK v1.3.14 相容性、Node 22 memory_search 競爭條件修復
 - **v0.6.3**: 索引建立守衛（空表/不足資料時延後建立，修復 #70）、LanceDB 0.27.2
 - **v0.6.2**: 修復索引競爭條件（並發衝突處理、jitter 重試）
 - **v0.6.1**: 事件 TTL/歸檔、索引建立彈性、去重複效能優化
 - **v0.6.0**: 新增學習儀表板、KPI 管線、反饋驅動排序、任務類型感知注入
-- **v0.5.0**: 新增記憶解釋工具 (`memory_why`, `memory_explain_recall`)
-- **v0.4.0**: 新增引用模型追蹤與驗證 (`memory_citation`, `memory_validate_citation`)
 
 _[舊版歷史請參閱 CHANGELOG.md]_
 
@@ -194,4 +193,4 @@ _[舊版歷史請參閱 CHANGELOG.md]_
 - **授權協議**: MIT License - 詳見 [LICENSE](LICENSE)。
 
 **最後更新**: 2026-04-09
-**最新版本**: v0.7.0
+**最新版本**: v0.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump version to 0.8.0. See CHANGELOG.md for details.