### PR TITLE
fix: release v0.8.2 - correct version to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ---
 
+## [0.8.2] - 2026-04-11
+
+### Fixed
+
+- **Plugin version mismatch** (internal):
+  - Issue #83: Fixed version mismatch between package.json and PLUGIN_VERSION in source code
+  - Evidence:
+    - Spec: N/A (bugfix)
+    - Code: src/index.ts (PLUGIN_VERSION sync)
+    - Tests: N/A
+    - Surface: internal-build
+
+---
+
 ## [0.8.1] - 2026-04-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancedb-opencode-pro",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "LanceDB-backed long-term memory provider for OpenCode",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { initLogger, log } from "./logger.js";
 import { calculateInjectionLimit, createSummarizationConfig, summarizeContent } from "./summarize.js";
 import { createMemoryTools, createFeedbackTools, createEpisodicTools, type ToolRuntimeState } from "./tools/index.js";
 
-const PLUGIN_VERSION = "0.8.1";
+const PLUGIN_VERSION = "0.8.2";
 
 const SCHEMA_VERSION = 1;
 


### PR DESCRIPTION
## Issue

Previous PR #84 failed to update the version (merged commit still shows 0.8.1).

### Fix
- package.json: 0.8.1 → 0.8.2
- src/index.ts: PLUGIN_VERSION 0.8.1 → 0.8.2
- CHANGELOG.md: Added v0.8.2 entry

### Verification
- [x] Local version check passes